### PR TITLE
Public Session init, fix some decoding issues, camel casing.

### DIFF
--- a/src/Models/ClientEvent.swift
+++ b/src/Models/ClientEvent.swift
@@ -3,7 +3,7 @@ import Foundation
 public enum ClientEvent: Equatable, Sendable {
 	public struct SessionUpdateEvent: Encodable, Equatable, Sendable {
 		/// Optional client-generated ID used to identify this event.
-		public var event_id: String?
+		public var eventId: String?
 		/// Session configuration to update.
 		public var session: Session
 
@@ -12,7 +12,7 @@ public enum ClientEvent: Equatable, Sendable {
 
 	public struct InputAudioBufferAppendEvent: Encodable, Equatable, Sendable {
 		/// Optional client-generated ID used to identify this event.
-		public var event_id: String?
+		public var eventId: String?
 		/// Base64-encoded audio bytes.
 		public var audio: String
 
@@ -21,23 +21,23 @@ public enum ClientEvent: Equatable, Sendable {
 
 	public struct InputAudioBufferCommitEvent: Encodable, Equatable, Sendable {
 		/// Optional client-generated ID used to identify this event.
-		public var event_id: String?
+		public var eventId: String?
 
 		private let type = "input_audio_buffer.commit"
 	}
 
 	public struct InputAudioBufferClearEvent: Encodable, Equatable, Sendable {
 		/// Optional client-generated ID used to identify this event.
-		public var event_id: String?
+		public var eventId: String?
 
 		private let type = "input_audio_buffer.clear"
 	}
 
 	public struct ConversationItemCreateEvent: Encodable, Equatable, Sendable {
 		/// Optional client-generated ID used to identify this event.
-		public var event_id: String?
+		public var eventId: String?
 		/// The ID of the preceding item after which the new item will be inserted.
-		public var previous_item_id: String?
+		public var previousItemId: String?
 		/// The item to add to the conversation.
 		public var item: Item
 
@@ -46,33 +46,33 @@ public enum ClientEvent: Equatable, Sendable {
 
 	public struct ConversationItemTruncateEvent: Encodable, Equatable, Sendable {
 		/// Optional client-generated ID used to identify this event.
-		public var event_id: String?
+		public var eventId: String?
 		/// The ID of the assistant message item to truncate.
-		public var item_id: String?
+		public var itemId: String?
 		/// The index of the content part to truncate.
-		public var content_index: Int
+		public var contentIndex: Int
 		/// Inclusive duration up to which audio is truncated, in milliseconds.
-		public var audio_end_ms: Int
+		public var audioEndMs: Int
 
 		private let type = "conversation.item.truncate"
 	}
 
 	public struct ConversationItemDeleteEvent: Encodable, Equatable, Sendable {
 		/// Optional client-generated ID used to identify this event.
-		public var event_id: String?
+		public var eventId: String?
 		/// The ID of the assistant message item to truncate.
-		public var item_id: String?
+		public var itemId: String?
 		/// The index of the content part to truncate.
-		public var content_index: Int
+		public var contentIndex: Int
 		/// Inclusive duration up to which audio is truncated, in milliseconds.
-		public var audio_end_ms: Int
+		public var audioEndMs: Int
 
 		private let type = "conversation.item.delete"
 	}
 
 	public struct ResponseCreateEvent: Encodable, Equatable, Sendable {
 		/// Optional client-generated ID used to identify this event.
-		public var event_id: String?
+		public var eventId: String?
 		/// Configuration for the response.
 		public var response: Response.Config?
 
@@ -81,7 +81,7 @@ public enum ClientEvent: Equatable, Sendable {
 
 	public struct ResponseCancelEvent: Encodable, Equatable, Sendable {
 		/// Optional client-generated ID used to identify this event.
-		public var event_id: String?
+		public var eventId: String?
 
 		private let type = "response.cancel"
 	}
@@ -108,39 +108,39 @@ public enum ClientEvent: Equatable, Sendable {
 
 public extension ClientEvent {
 	static func updateSession(id: String? = nil, _ session: Session) -> Self {
-		.updateSession(SessionUpdateEvent(event_id: id, session: session))
+		.updateSession(SessionUpdateEvent(eventId: id, session: session))
 	}
 
 	static func appendInputAudioBuffer(id: String? = nil, encoding audio: Data) -> Self {
-		.appendInputAudioBuffer(InputAudioBufferAppendEvent(event_id: id, audio: audio.base64EncodedString()))
+		.appendInputAudioBuffer(InputAudioBufferAppendEvent(eventId: id, audio: audio.base64EncodedString()))
 	}
 
 	static func commitInputAudioBuffer(id: String? = nil) -> Self {
-		.commitInputAudioBuffer(InputAudioBufferCommitEvent(event_id: id))
+		.commitInputAudioBuffer(InputAudioBufferCommitEvent(eventId: id))
 	}
 
 	static func clearInputAudioBuffer(id: String? = nil) -> Self {
-		.clearInputAudioBuffer(InputAudioBufferClearEvent(event_id: id))
+		.clearInputAudioBuffer(InputAudioBufferClearEvent(eventId: id))
 	}
 
 	static func createConversationItem(id: String? = nil, previous previousID: String? = nil, _ item: Item) -> Self {
-		.createConversationItem(ConversationItemCreateEvent(event_id: id, previous_item_id: previousID, item: item))
+		.createConversationItem(ConversationItemCreateEvent(eventId: id, previousItemId: previousID, item: item))
 	}
 
-	static func truncateConversationItem(id event_id: String? = nil, for id: String? = nil, at index: Int, at_audio audio_index: Int) -> Self {
-		.truncateConversationItem(ConversationItemTruncateEvent(event_id: event_id, item_id: id, content_index: index, audio_end_ms: audio_index))
+	static func truncateConversationItem(id eventId: String? = nil, for id: String? = nil, at index: Int, atAudio audioIndex: Int) -> Self {
+		.truncateConversationItem(ConversationItemTruncateEvent(eventId: eventId, itemId: id, contentIndex: index, audioEndMs: audioIndex))
 	}
 
-	static func deleteConversationItem(id event_id: String? = nil, for id: String? = nil, at index: Int, at_audio audio_index: Int) -> Self {
-		.deleteConversationItem(ConversationItemDeleteEvent(event_id: event_id, item_id: id, content_index: index, audio_end_ms: audio_index))
+	static func deleteConversationItem(id eventId: String? = nil, for id: String? = nil, at index: Int, atAudio audioIndex: Int) -> Self {
+		.deleteConversationItem(ConversationItemDeleteEvent(eventId: eventId, itemId: id, contentIndex: index, audioEndMs: audioIndex))
 	}
 
 	static func createResponse(id: String? = nil, _ response: Response.Config? = nil) -> Self {
-		.createResponse(ResponseCreateEvent(event_id: id, response: response))
+		.createResponse(ResponseCreateEvent(eventId: id, response: response))
 	}
 
 	static func cancelResponse(id: String? = nil) -> Self {
-		.cancelResponse(ResponseCancelEvent(event_id: id))
+		.cancelResponse(ResponseCancelEvent(eventId: id))
 	}
 }
 

--- a/src/Models/Item.swift
+++ b/src/Models/Item.swift
@@ -80,7 +80,7 @@ public enum Item: Identifiable, Equatable, Sendable {
 		/// The role associated with the item
 		public var role: ItemRole
 		/// The ID of the function call
-		public var call_id: String
+		public var callId: String
 		/// The name of the function being called
 		public var name: String
 		/// The arguments of the function call
@@ -97,7 +97,7 @@ public enum Item: Identifiable, Equatable, Sendable {
 		/// The role associated with the item
 		public var role: ItemRole
 		/// The ID of the function call
-		public var call_id: String
+		public var callId: String
 		/// The output of the function call
 		public var output: String
 	}

--- a/src/Models/Item.swift
+++ b/src/Models/Item.swift
@@ -3,7 +3,7 @@ import Foundation
 public enum Item: Identifiable, Equatable, Sendable {
 	public enum ItemStatus: String, Codable, Sendable {
 		case completed
-		case in_progress
+		case inProgress = "in_progress"
 		case incomplete
 	}
 
@@ -78,16 +78,16 @@ public enum Item: Identifiable, Equatable, Sendable {
 		public enum Content: Codable, Equatable, Sendable {
 			case text(String)
 			case audio(Audio)
-			case input_text(String)
-			case input_audio(Audio)
+			case inputText(String)
+			case inputAudio(Audio)
 
 			public var text: String? {
 				switch self {
 					case let .text(text):
 						return text
-					case let .input_text(text):
+					case let .inputText(text):
 						return text
-					case let .input_audio(audio):
+					case let .inputAudio(audio):
 						return audio.transcript
 					case let .audio(audio):
 						return audio.transcript
@@ -119,11 +119,11 @@ public enum Item: Identifiable, Equatable, Sendable {
 						self = try .text(container.decode(String.self, forKey: .text))
 					case "input_text":
 						let container = try decoder.container(keyedBy: Text.CodingKeys.self)
-						self = try .input_text(container.decode(String.self, forKey: .text))
+						self = try .inputText(container.decode(String.self, forKey: .text))
 					case "audio":
 						self = try .audio(Audio(from: decoder))
 					case "input_audio":
-						self = try .input_audio(Audio(from: decoder))
+						self = try .inputAudio(Audio(from: decoder))
 					default:
 						throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown content type: \(type)")
 				}
@@ -136,14 +136,14 @@ public enum Item: Identifiable, Equatable, Sendable {
 					case let .text(text):
 						try container.encode(text, forKey: .text)
 						try container.encode("text", forKey: .type)
-					case let .input_text(text):
+					case let .inputText(text):
 						try container.encode(text, forKey: .text)
 						try container.encode("input_text", forKey: .type)
 					case let .audio(audio):
 						try container.encode("audio", forKey: .type)
 						try container.encode(audio.audio, forKey: .audio)
 						try container.encode(audio.transcript, forKey: .transcript)
-					case let .input_audio(audio):
+					case let .inputAudio(audio):
 						try container.encode(audio.audio, forKey: .audio)
 						try container.encode("input_audio", forKey: .type)
 						try container.encode(audio.transcript, forKey: .transcript)
@@ -180,7 +180,7 @@ public enum Item: Identifiable, Equatable, Sendable {
 		/// The role associated with the item
 		public var role: ItemRole
 		/// The ID of the function call
-		public var call_id: String
+		public var callId: String
 		/// The name of the function being called
 		public var name: String
 		/// The arguments of the function call
@@ -197,7 +197,7 @@ public enum Item: Identifiable, Equatable, Sendable {
 		/// The role associated with the item
 		public var role: ItemRole
 		/// The ID of the function call
-		public var call_id: String
+		public var callId: String
 		/// The output of the function call
 		public var output: String
 	}

--- a/src/Models/Response.swift
+++ b/src/Models/Response.swift
@@ -7,15 +7,15 @@ public struct Response: Identifiable, Codable, Equatable, Sendable {
 		/// The voice the model uses to respond.
 		public let voice: Session.Voice
 		/// The format of output audio.
-		public let output_audio_format: Session.AudioFormat
+		public let outputAudioFormat: Session.AudioFormat
 		/// Tools (functions) available to the model.
 		public let tools: [Session.Tool]
 		/// How the model chooses tools.
-		public let tool_choice: Session.ToolChoice
+		public let toolChoice: Session.ToolChoice
 		/// Sampling temperature.
 		public let temperature: Double
 		/// Maximum number of output tokens.
-		public let max_output_tokens: Int?
+		public let maxOutputTokens: Int?
 	}
 
 	public enum Status: String, Codable, Equatable, Sendable {
@@ -23,13 +23,13 @@ public struct Response: Identifiable, Codable, Equatable, Sendable {
 		case completed
 		case cancelled
 		case incomplete
-		case in_progress
+		case inProgress = "in_progress"
 	}
 
 	public struct Usage: Codable, Equatable, Sendable {
-		public let total_tokens: Int
-		public let input_tokens: Int
-		public let output_tokens: Int
+		public let totalTokens: Int
+		public let inputTokens: Int
+		public let outputTokens: Int
 	}
 
 	/// The unique ID of the response.

--- a/src/Models/ServerError.swift
+++ b/src/Models/ServerError.swift
@@ -7,6 +7,6 @@ public struct ServerError: Codable, Equatable, Sendable {
 	public let message: String
 	/// Parameter related to the error, if any.
 	public let param: String?
-	/// The event_id of the client event that caused the error, if applicable.
-	public let event_id: String?
+	/// The eventId of the client event that caused the error, if applicable.
+	public let eventId: String?
 }

--- a/src/Models/ServerEvent.swift
+++ b/src/Models/ServerEvent.swift
@@ -1,14 +1,14 @@
 public enum ServerEvent: Sendable {
 	public struct ErrorEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// Details of the error.
 		public let error: ServerError
 	}
 
 	public struct SessionEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The session resource.
 		public let session: Session
 	}
@@ -20,265 +20,265 @@ public enum ServerEvent: Sendable {
 		}
 
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The conversation resource.
 		public let conversation: Conversation
 	}
 
 	public struct InputAudioBufferCommittedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the preceding item after which the new item will be inserted.
-		public let previous_item_id: String?
+		public let previousItemId: String?
 		/// The ID of the user message item that will be created.
-		public let item_id: String
+		public let itemId: String
 	}
 
 	public struct InputAudioBufferClearedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 	}
 
 	public struct InputAudioBufferSpeechStartedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// Milliseconds since the session started when speech was detected.
-		public let audio_start_ms: Int
+		public let audioStartMs: Int
 		/// The ID of the user message item that will be created when speech stops.
-		public let item_id: String
+		public let itemId: String
 	}
 
 	public struct InputAudioBufferSpeechStoppedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// Milliseconds since the session started when speech stopped.
-		public let audio_end_ms: Int
+		public let audioEndMs: Int
 		/// The ID of the user message item that will be created.
-		public let item_id: String
+		public let itemId: String
 	}
 
 	public struct ConversationItemCreatedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the preceding item.
-		public let previous_item_id: String?
+		public let previousItemId: String?
 		/// The item that was created.
 		public let item: Item
 	}
 
 	public struct ConversationItemInputAudioTranscriptionCompletedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the user message item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the content part containing the audio.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// The transcribed text.
-		public let transcription: String
+		public let transcript: String
 	}
 
 	public struct ConversationItemInputAudioTranscriptionFailedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the user message item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the content part containing the audio.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// Details of the transcription error.
 		public let error: ServerError
 	}
 
 	public struct ConversationItemTruncatedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the assistant message item that was truncated.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the content part that was truncated.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// The duration up to which the audio was truncated, in milliseconds.
-		public let audio_end_ms: Int
+		public let audioEndMs: Int
 	}
 
 	public struct ConversationItemDeletedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the item that was deleted.
-		public let item_id: String
+		public let itemId: String
 	}
 
 	public struct ResponseEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The response resource.
 		public let response: Response
 	}
 
 	public struct ResponseOutputItemAddedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response to which the item belongs.
-		public let response_id: String
+		public let responseId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The item that was added.
 		public let item: Item
 	}
 
 	public struct ResponseOutputItemDoneEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response to which the item belongs.
-		public let response_id: String
+		public let responseId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The completed item.
 		public let item: Item
 	}
 
 	public struct ResponseContentPartAddedEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the item to which the content part was added.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The index of the content part in the item's content array.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// The content part that was added.
 		public let part: Item.ContentPart
 	}
 
 	public struct ResponseContentPartDoneEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The index of the content part in the item's content array.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// The content part that is done.
 		public let part: Item.ContentPart
 	}
 
 	public struct ResponseTextDeltaEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The index of the content part in the item's content array.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// The text delta.
 		public let delta: String
 	}
 
 	public struct ResponseTextDoneEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The index of the content part in the item's content array.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// The final text content.
 		public let text: String
 	}
 
 	public struct ResponseAudioTranscriptDeltaEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The index of the content part in the item's content array.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// The transcript delta.
 		public let delta: String
 	}
 
 	public struct ResponseAudioTranscriptDoneEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The index of the content part in the item's content array.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// The final transcript of the audio.
 		public let transcript: String
 	}
 
 	public struct ResponseAudioDeltaEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The index of the content part in the item's content array.
-		public let content_index: Int
+		public let contentIndex: Int
 		/// Base64-encoded audio data delta.
 		public let delta: String
 	}
 
 	public struct ResponseAudioDoneEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The index of the content part in the item's content array.
-		public let content_index: Int
+		public let contentIndex: Int
 	}
 
 	public struct ResponseFunctionCallArgumentsDeltaEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the function call item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The ID of the function call.
-		public let call_id: String
+		public let callId: String
 		/// The arguments delta as a JSON string.
 		public let delta: String
 	}
 
 	public struct ResponseFunctionCallArgumentsDoneEvent: Codable, Sendable {
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// The ID of the response.
-		public let response_id: String
+		public let responseId: String
 		/// The ID of the function call item.
-		public let item_id: String
+		public let itemId: String
 		/// The index of the output item in the response.
-		public let output_index: Int
+		public let outputIndex: Int
 		/// The ID of the function call.
-		public let call_id: String
+		public let callId: String
 		/// The final arguments as a JSON string.
 		public let arguments: String
 	}
@@ -292,13 +292,13 @@ public enum ServerEvent: Sendable {
 			/// The remaining value before the limit is reached.
 			public let remaining: Int
 			/// Seconds until the rate limit resets.
-			public let reset_seconds: Double
+			public let resetSeconds: Double
 		}
 
 		/// The unique ID of the server event.
-		public let event_id: String
+		public let eventId: String
 		/// List of rate limit information.
-		public let rate_limits: [RateLimit]
+		public let rateLimits: [RateLimit]
 	}
 
 	/// Returned when an error occurs.
@@ -363,61 +363,61 @@ extension ServerEvent: Identifiable {
 	public var id: String {
 		switch self {
 			case let .error(event):
-				return event.event_id
+				return event.eventId
 			case let .sessionCreated(event):
-				return event.event_id
+				return event.eventId
 			case let .sessionUpdated(event):
-				return event.event_id
+				return event.eventId
 			case let .conversationCreated(event):
-				return event.event_id
+				return event.eventId
 			case let .inputAudioBufferCommitted(event):
-				return event.event_id
+				return event.eventId
 			case let .inputAudioBufferCleared(event):
-				return event.event_id
+				return event.eventId
 			case let .inputAudioBufferSpeechStarted(event):
-				return event.event_id
+				return event.eventId
 			case let .inputAudioBufferSpeechStopped(event):
-				return event.event_id
+				return event.eventId
 			case let .conversationItemCreated(event):
-				return event.event_id
+				return event.eventId
 			case let .conversationItemInputAudioTranscriptionCompleted(event):
-				return event.event_id
+				return event.eventId
 			case let .conversationItemInputAudioTranscriptionFailed(event):
-				return event.event_id
+				return event.eventId
 			case let .conversationItemTruncated(event):
-				return event.event_id
+				return event.eventId
 			case let .conversationItemDeleted(event):
-				return event.event_id
+				return event.eventId
 			case let .responseCreated(event):
-				return event.event_id
+				return event.eventId
 			case let .responseDone(event):
-				return event.event_id
+				return event.eventId
 			case let .responseOutputItemAdded(event):
-				return event.event_id
+				return event.eventId
 			case let .responseOutputItemDone(event):
-				return event.event_id
+				return event.eventId
 			case let .responseContentPartAdded(event):
-				return event.event_id
+				return event.eventId
 			case let .responseContentPartDone(event):
-				return event.event_id
+				return event.eventId
 			case let .responseTextDelta(event):
-				return event.event_id
+				return event.eventId
 			case let .responseTextDone(event):
-				return event.event_id
+				return event.eventId
 			case let .responseAudioTranscriptDelta(event):
-				return event.event_id
+				return event.eventId
 			case let .responseAudioTranscriptDone(event):
-				return event.event_id
+				return event.eventId
 			case let .responseAudioDelta(event):
-				return event.event_id
+				return event.eventId
 			case let .responseAudioDone(event):
-				return event.event_id
+				return event.eventId
 			case let .responseFunctionCallArgumentsDelta(event):
-				return event.event_id
+				return event.eventId
 			case let .responseFunctionCallArgumentsDone(event):
-				return event.event_id
+				return event.eventId
 			case let .rateLimitsUpdated(event):
-				return event.event_id
+				return event.eventId
 		}
 	}
 }

--- a/src/Models/ServerEvent.swift
+++ b/src/Models/ServerEvent.swift
@@ -498,22 +498,22 @@ extension ServerEvent: Decodable {
 
 extension ServerEvent.ResponseAudioDeltaEvent: Decodable {
 	private enum CodingKeys: CodingKey {
-		case event_id
-		case response_id
-		case item_id
-		case output_index
-		case content_index
+		case eventId
+		case responseId
+		case itemId
+		case outputIndex
+		case contentIndex
 		case delta
 	}
 
 	public init(from decoder: any Decoder) throws {
 		let container = try decoder.container(keyedBy: CodingKeys.self)
 
-		item_id = try container.decode(String.self, forKey: .item_id)
-		event_id = try container.decode(String.self, forKey: .event_id)
-		output_index = try container.decode(Int.self, forKey: .output_index)
-		response_id = try container.decode(String.self, forKey: .response_id)
-		content_index = try container.decode(Int.self, forKey: .content_index)
+        itemId = try container.decode(String.self, forKey: .itemId)
+		eventId = try container.decode(String.self, forKey: .eventId)
+		outputIndex = try container.decode(Int.self, forKey: .outputIndex)
+		responseId = try container.decode(String.self, forKey: .responseId)
+		contentIndex = try container.decode(Int.self, forKey: .contentIndex)
 
 		guard let decodedDelta = try Data(base64Encoded: container.decode(String.self, forKey: .delta)) else {
 			throw DecodingError.dataCorruptedError(forKey: .delta, in: container, debugDescription: "Invalid base64-encoded audio data.")

--- a/src/Models/Session.swift
+++ b/src/Models/Session.swift
@@ -20,13 +20,22 @@ public struct Session: Codable, Equatable, Sendable {
 	}
 
 	public struct InputAudioTranscription: Codable, Equatable, Sendable {
+        /* The enabled property should exist going by the events page, however fails to update if it does.
+            - https://platform.openai.com/docs/api-reference/realtime-client-events/session-update
+         
 		public var enabled: Bool
+        */
 		public var model: String
+        
+        public init(enabled: Bool = true, model: String = "whisper-1") {
+//            self.enabled = enabled
+            self.model = model
+        }
 	}
 
 	public struct TurnDetection: Codable, Equatable, Sendable {
 		public enum TurnDetectionType: String, Codable, Sendable {
-			case server_vad
+			case serverVad = "server_vad"
 			case none
 		}
 
@@ -35,9 +44,21 @@ public struct Session: Codable, Equatable, Sendable {
 		/// Activation threshold for VAD (0.0 to 1.0).
 		public var threshold: Double
 		/// Amount of audio to include before speech starts (in milliseconds).
-		public var prefix_padding_ms: Int
+		public var prefixPaddingMs: Int
 		/// Duration of silence to detect speech stop (in milliseconds).
-		public var silence_duration_ms: Int
+		public var silenceDurationMs: Int
+        
+        public init(
+            type: TurnDetectionType,
+            threshold: Double,
+            prefixPaddingMs: Int,
+            silenceDurationMs: Int
+        ) {
+            self.type = type
+            self.threshold = threshold
+            self.prefixPaddingMs = prefixPaddingMs
+            self.silenceDurationMs = silenceDurationMs
+        }
 	}
 
 	public struct Tool: Codable, Equatable, Sendable {
@@ -252,27 +273,57 @@ public struct Session: Codable, Equatable, Sendable {
 	/// The unique ID of the session.
 	public var id: String?
 	/// The default model used for this session.
-	public var model: String
+	public var model: String?
 	/// The set of modalities the model can respond with.
-	public var modalities: [Modality]
+	public var modalities: [Modality]?
 	/// The default system instructions.
-	public var instructions: String
+	public var instructions: String?
 	/// The voice the model uses to respond.
 	public var voice: Voice
 	/// The format of input audio.
-	public var input_audio_format: AudioFormat
+	public var inputAudioFormat: AudioFormat
 	/// The format of output audio.
-	public var output_audio_format: AudioFormat
+	public var outputAudioFormat: AudioFormat
 	/// Configuration for input audio transcription.
-	public var input_audio_transcription: InputAudioTranscription?
+	public var inputAudioTranscription: InputAudioTranscription?
 	/// Configuration for turn detection.
-	public var turn_detection: TurnDetection?
+	public var turnDetection: TurnDetection?
 	/// Tools (functions) available to the model.
 	public var tools: [Tool]
 	/// How the model chooses tools.
-	public var tool_choice: ToolChoice
+	public var toolChoice: ToolChoice
 	/// Sampling temperature.
-	public var temperature: Double
+	public var temperature: Double?
 	/// Maximum number of output tokens.
-	public var max_output_tokens: Int?
+	public var maxOutputTokens: Int?
+    
+    public init(
+        id: String? = nil,
+        model: String? = nil,
+        modalities: [Modality]? = nil,
+        instructions: String? = nil,
+        voice: Voice = .alloy,
+        inputAudioFormat: AudioFormat = .pcm16,
+        outputAudioFormat: AudioFormat = .pcm16,
+        inputAudioTranscription: InputAudioTranscription? = nil,
+        turnDetection: TurnDetection? = nil,
+        tools: [Tool] = [],
+        toolChoice: ToolChoice = .auto,
+        temperature: Double? = nil,
+        maxOutputTokens: Int? = nil
+    ) {
+        self.id = id
+        self.model = model
+        self.modalities = modalities
+        self.instructions = instructions
+        self.voice = voice
+        self.inputAudioFormat = inputAudioFormat
+        self.outputAudioFormat = outputAudioFormat
+        self.inputAudioTranscription = inputAudioTranscription
+        self.turnDetection = turnDetection
+        self.tools = tools
+        self.toolChoice = toolChoice
+        self.temperature = temperature
+        self.maxOutputTokens = maxOutputTokens
+    }
 }

--- a/src/OpenAI.swift
+++ b/src/OpenAI.swift
@@ -3,8 +3,16 @@ import Foundation
 public final class RealtimeAPI: NSObject, Sendable {
 	public let events: AsyncThrowingStream<ServerEvent, Error>
 
-	private let encoder = JSONEncoder()
-	private let decoder = JSONDecoder()
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        return encoder
+    }()
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
 	private let task: URLSessionWebSocketTask
 	private let stream: AsyncThrowingStream<ServerEvent, Error>.Continuation
 
@@ -19,12 +27,12 @@ public final class RealtimeAPI: NSObject, Sendable {
 		task.resume()
 	}
 
-	public convenience init(auth_token: String, model: String = "gpt-4o-realtime-preview-2024-10-01") {
+	public convenience init(authToken: String, model: String = "gpt-4o-realtime-preview-2024-10-01") {
 		var request = URLRequest(url: URL(string: "wss://api.openai.com/v1/realtime")!.appending(queryItems: [
 			URLQueryItem(name: "model", value: model),
 		]))
 		request.addValue("realtime=v1", forHTTPHeaderField: "OpenAI-Beta")
-		request.addValue("Bearer \(auth_token)", forHTTPHeaderField: "Authorization")
+		request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
 
 		self.init(connectingTo: request)
 	}


### PR DESCRIPTION
* Created a public init for Session. Was not possible to update the session otherwise.
* Fixed decoding of `ConversationItemInputAudioTranscriptionCompletedEvent`.
  * typo with `transcription` property that should be `transcript`.
* Used camel case with all properties to make everything feel more "Swifty". Using `convertToSnakeCase` and `convertFromSnakeCase` in the encoder and decoder.