### PR TITLE
Add `inputTokenDetails` and `outputTokenDetails` to `Response.usage`

### DIFF
--- a/src/Models/Response.swift
+++ b/src/Models/Response.swift
@@ -57,6 +57,25 @@ public struct Response: Identifiable, Codable, Equatable, Sendable {
 		public let totalTokens: Int
 		public let inputTokens: Int
 		public let outputTokens: Int
+		public let inputTokenDetails: InputTokenDetails
+		public let outputTokenDetails: OutputTokenDetails
+
+		public struct InputTokenDetails: Codable, Equatable, Sendable {
+			public let textTokens: Int
+			public let audioTokens: Int
+			public let cachedTokens: Int
+			public let cachedTokensDetails: CachedTokensDetails
+
+			public struct CachedTokensDetails: Codable, Equatable, Sendable {
+				public let textTokens: Int
+				public let audioTokens: Int
+			}
+		}
+
+		public struct OutputTokenDetails: Codable, Equatable, Sendable {
+			public let textTokens: Int
+			public let audioTokens: Int
+		}
 	}
 
 	/// The unique ID of the response.


### PR DESCRIPTION
Add new properties to the `Response.usage` object to reflect the following structure:
https://platform.openai.com/docs/guides/realtime-conversations#detect-when-the-model-wants-to-call-a-function
```
    "usage": {
      "total_tokens": 541,
      "input_tokens": 521,
      "output_tokens": 20,
      "input_token_details": {
        "text_tokens": 292,
        "audio_tokens": 229,
        "cached_tokens": 0,
        "cached_tokens_details": { "text_tokens": 0, "audio_tokens": 0 }
      },
      "output_token_details": {
        "text_tokens": 20,
        "audio_tokens": 0
      }
    },
```