### PR TITLE
Fix incorrect isPlaying state logic in Conversation class

### DIFF
--- a/src/Conversation.swift
+++ b/src/Conversation.swift
@@ -502,7 +502,7 @@ extension Conversation {
 			Task { @MainActor in
 				guard let self else { return }
 
-				self.isPlaying = self.queuedSamples.isEmpty
+				self.isPlaying = !self.queuedSamples.isEmpty
 			}
 
 			self?._keepIsPlayingPropertyUpdated()


### PR DESCRIPTION
Fixes #38 

This PR fixes a bug in the isPlaying property state management. In commit [a397fea](https://github.com/m1guelpf/swift-realtime-openai/commit/a397feab7f38468501727b51c15c70ddb61aa05e), the logic for setting the isPlaying property was inverted, causing incorrect behavior in the audio playback status reporting.

The current implementation sets isPlaying to true when the queuedSamples array is empty and false when samples are available for playback, which is the opposite of the expected behavior. This PR corrects the logic by inverting the condition.