### PR TITLE
Add output_audio_buffer.cleared server event

### DIFF
--- a/Sources/Core/Models/ServerEvent.swift
+++ b/Sources/Core/Models/ServerEvent.swift
@@ -224,6 +224,13 @@ import MetaCodable
 	@CodedAs("output_audio_buffer.stopped")
 	case outputAudioBufferStopped(eventId: String, responseId: String)
 
+	/// Returned when the output audio buffer is cleared.
+	///
+	/// - Parameter eventId: The unique ID of the server event.
+	/// - Parameter responseId: The ID of the Response to which the output audio belongs.
+	@CodedAs("output_audio_buffer.cleared")
+	case outputAudioBufferCleared(eventId: String, responseId: String)
+
 	/// Returned when a new Response is created.
 	///
 	/// The first event of response creation, where the response is in an initial state of `inProgress`.
@@ -548,6 +555,7 @@ extension ServerEvent: Identifiable {
 			case let .inputAudioBufferTimeoutTriggered(id, _, _, _): id
 			case let .outputAudioBufferStarted(id, _): id
 			case let .outputAudioBufferStopped(id, _): id
+			case let .outputAudioBufferCleared(id, _): id
 			case let .responseCreated(id, _): id
 			case let .responseDone(id, _): id
 			case let .responseOutputItemAdded(id, _, _, _): id


### PR DESCRIPTION
Minor fix, I noticed this even isn't being recognized causing an unrecoverable error when using Conversation api